### PR TITLE
Build binary ci

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -1,0 +1,45 @@
+name: binaries
+
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    tags:
+
+env:
+  go_version: 1.18.5
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.go_version }}
+
+
+    - run: echo "IMAGE_TAG=dev" >> $GITHUB_ENV
+      if: ${{ github.ref_name }} == 'main'
+    - run: echo "IMAGE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      if: startsWith(github.ref, 'refs/tags/v')
+    
+    - run: sudo apt-get update -y && sudo apt-get install -y rsync
+    - name: build
+      id: build
+      run: |
+        cd avalanchego
+        ./scripts/build.sh
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-bin
+        path: |
+          avalanchego/build

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   go_version: 1.18.5
+  GOPATH: ~/.go
 
 jobs:
   build:

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -9,7 +9,6 @@ on:
 
 env:
   go_version: 1.18.5
-  GOPATH: ~/.go
 
 jobs:
   build:
@@ -33,6 +32,8 @@ jobs:
     
     - run: sudo apt-get update -y && sudo apt-get install -y rsync
     - name: build
+      env:
+        GOPATH: /home/runner/work/go-songbird/go
       id: build
       run: |
         cd avalanchego


### PR DESCRIPTION
Introduce a workflow that builds avalanchego binaries and stores them as job artifacts