### PR TITLE
Add exec to entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ then
 	BOOTSTRAP_IDS=$(curl -m 10 -sX POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeID" }' -H 'content-type:application/json;' "$AUTOCONFIGURE_BOOTSTRAP_ENDPOINT" | jq -r ".result.nodeID")
 fi
 
-/app/build/flare \
+exec /app/build/flare \
 	--http-host=$HTTP_HOST \
 	--http-port=$HTTP_PORT \
 	--staking-port=$STAKING_PORT \


### PR DESCRIPTION
Add exec when lunching the songbird node binary so SIGINT signal is send directly to the process instead of killing in after kill timeout (better graceful shutdown)